### PR TITLE
Make `nix build` work by relaxing `vty` bound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ cabal.project.local~
 # vim swap files
 *.swp
 *.swo
+
+# nix
+result

--- a/herms.cabal
+++ b/herms.cabal
@@ -116,7 +116,7 @@ executable herms
                      , mtl >=2.2.1 && <2.3
                      , optparse-applicative >=0.14 && <0.16
                      , text-zipper >=0.10 && <0.11
-                     , vty >=5.26 && <5.27
+                     , vty >=5.25 && <5.27
                      , yaml >=0.10 && <0.12
 
 test-suite herms-test


### PR DESCRIPTION
Relates to #120.

`cabal v2-test` is confirmed to pass.