### PR TITLE
Add git build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Herms binaries
 
 on:
     push:
-        # For example...
+        # Don't build when these change:
         paths-ignore:
         - 'README.md'
 
@@ -22,16 +22,16 @@ jobs:
 
       - name: Build
         shell: bash
-	run: stack build --copy-bins --local-bin-path .
+        run: stack build --copy-bins --local-bin-path .
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
-	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-	  body_path: changelog
-	  draft: true
+          body_path: changelog
+          draft: true
           files: |
             herms
             LICENSE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,18 @@ jobs:
 
       - name: Build
         shell: bash
-	run: stack build
+	run: stack build --copy-bins --local-bin-path .
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
-	        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+	  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+	  body_path: changelog
+	  draft: true
+          files: |
+            herms
+            LICENSE
+            changelog
+            README.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,11 @@ name: Build Herms binaries
 
 on:
     push:
+        tags:
+          - '*'
         # Don't build when these change:
         paths-ignore:
-        - 'README.md'
+          - '*.md'
 
 jobs:
   build:
@@ -35,5 +37,8 @@ jobs:
           files: |
             herms
             LICENSE
-            changelog
             README.md
+            data/config.hs
+            data/recipes.yaml
+            data/recipes.herms
+            # herms needs an installer, for putting config.hs and recipes.yaml in their places.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build Herms binaries
+
+on:
+    push:
+	# For example...
+        paths-ignore:
+        - 'README.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Setup stack
+        uses: mstksg/setup-stack@v1
+
+      - name: Dependencies
+        shell: bash
+        run: stack update
+
+      - name: Build
+        shell: bash
+	run: stack build
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+	        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For #67, here's a workflow that builds herms when you push a tag to github. Since herms is a heavy build (it clocks in at 10 minutes on github) I limited it to tagged versions; you can remove that limitation by removing the `tags:` part in the workflow.

This also creates a release when it finishes building. I set it to default to a draft release (`draft:`), and it's pulling the entire changelog in as the release message (`body_path:`); you'll want to tweak that, probably.

Finally, I realized that herms could probably benefit from a proper install script, given that it depends on file paths that are hard-coded in by `stack`. Although they are included in the release as assets, it still requires manual download and copying, and knowing where things need to go, and so on.

To kick this off, you need to tag the repo and push the tag.  Or get rid of the tag trigger in the `build.yml`; either way.