### PR TITLE
feat: specify utf-8 encoding on exported html

### DIFF
--- a/src/Html.hs
+++ b/src/Html.hs
@@ -66,7 +66,8 @@ htmlDoc cssUrl bodyHtml =
         mconcat
           [ head $
               mconcat
-                [ case cssUrl of
+                [ "<meta charset=\"UTF-8\">"
+                , case cssUrl of
                     Just url ->  "<link rel=\"stylesheet\" href=\"" ++ url ++ "\">"
                     Nothing -> ""
                 , title "Recipes"


### PR DESCRIPTION
This PR adds a meta tag to the HTML layout of exported docs in order to specify UTF-8 as the document's charset, as suggested in issue #134. This is done at the beginning of the `<head>` block, right before any other tags.

Closes #134 (if merged).

Let me know if I missed something or if there's anything else I can help with!