### PR TITLE
refactor: remove unused arg on `listByTags`

### DIFF
--- a/app/herms.hs
+++ b/app/herms.hs
@@ -251,7 +251,7 @@ list inputTags groupByTags nameOnly = do
   let recipesWithIndex = zip [1..] recipes
   let targetRecipes    = filterByTags inputTags recipesWithIndex
   if groupByTags
-  then listByTags nameOnly inputTags targetRecipes
+  then listByTags nameOnly targetRecipes
   else listDefault nameOnly targetRecipes
 
 filterByTags :: [String] -> [(Int, Recipe)] -> [(Int, Recipe)]
@@ -270,8 +270,8 @@ listDefault nameOnly (unzip -> (indices, recipes)) = do
   then mapM_ (putStrLn . recipeName) recipes
   else mapM_ putTextLn $ zipWith (\ i -> ((i ~~ ". ") ~~)) strIndices recipeList
 
-listByTags :: Bool -> [String] -> [(Int, Recipe)] -> HermsReader IO ()
-listByTags nameOnly inputTags recipesWithIdx = do
+listByTags :: Bool -> [(Int, Recipe)] -> HermsReader IO ()
+listByTags nameOnly recipesWithIdx = do
   (config, _) <- ask
   let tagsRecipes :: [[(String, (Int, Recipe))]]
       tagsRecipes =


### PR DESCRIPTION
While compiling the project in order to run the tests in #137, GHC spew out this warning:

```bash
path/to/herms/app/herms.hs:274:21: warning: [-Wunused-matches]
    Defined but not used: ‘inputTags’
    |       
274 | listByTags nameOnly inputTags recipesWithIdx = do
    |                     ^^^^^^^^^
```

I checked the code and `listByTags` was only being called by `list` (in the same file), and sure enough the parameter `inputTags` was not being used, so I removed it from `listByTags`'s signature and type annotation, and removed the value being passed as an argument in the call within `list`.

All tests passed (at least in my local environment) and I could run the tool to list the recipes successfully.

As before, let me know if there's anything else I could do to help!